### PR TITLE
Sort set members, display as bullet list

### DIFF
--- a/templates/key.html
+++ b/templates/key.html
@@ -49,7 +49,7 @@
 		<h2>String Value</h2>
 		<code>{{ value }}</code>
 
-	{% elif type == "list" or type == "set" or type == "zset" %}
+	{% elif type == "list" or type == "zset" %}
 
 		<h2>Values</h2>
 		<ol>
@@ -57,6 +57,15 @@
 			<li><code>{{ item }}</code></li>
 		{% endfor %}
 		</ol>
+
+	{% elif type == "set" %}
+
+		<h2>Values</h2>
+		<ul>
+		{% for item in value|sort %}
+			<li><code>{{ item }}</code></li>
+		{% endfor %}
+		</ul>
 
 	{% elif type == "hash" %}
 


### PR DESCRIPTION
Using bullets (ul) to communicate that the order is not significant.
Sorting the list members to make the display more stable and simplify
finding a specific member.

Closes #2
